### PR TITLE
bug-fixes

### DIFF
--- a/architecture/create-benchmark-rules.yaml
+++ b/architecture/create-benchmark-rules.yaml
@@ -320,9 +320,10 @@
 
     ConfigRuleForEvaluateRootAccount:
       Type: AWS::Config::ConfigRule
-      DependsOn: ResourceForEvaluateCisBenchmarkingPreconditions
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - EvaluateRootAccountFunctionPermission
       Condition: IsLevel2
-      DependsOn: EvaluateRootAccountFunctionPermission
       Properties:
         ConfigRuleName: RootAccoutMustHaveMfaEnabled
         Description: Evaluates the security properties of the root account.
@@ -843,7 +844,6 @@
                     ResultToken=result_token
                 )
 
-        Description: Evaluates whether VPC Flow Logs are enabled for the VPCs
         Handler: index.lambda_handler
         MemorySize: 1024
         Role: !GetAtt MasterConfigRole.Arn
@@ -1670,6 +1670,7 @@
         Period: 60
         Statistic: Sum
         Threshold: 5
+        TreatMissingData: notBreaching
 
     #==================================================
     # CIS 1.1 Avoid the use of the "root" account
@@ -1707,6 +1708,7 @@
         Period: 60
         Statistic: Sum
         Threshold: 1
+        TreatMissingData: notBreaching
 
     #==================================================
     # CIS 3.2	Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
@@ -1742,6 +1744,7 @@
         Period: 60
         Statistic: Sum
         Threshold: 1
+        TreatMissingData: notBreaching
 
     #==================================================
     # CIS 3.6	Ensure a log metric filter and alarm exist for AWS Management Console authentication failures
@@ -1778,6 +1781,7 @@
         Period: 300
         Statistic: Sum
         Threshold: 1
+        TreatMissingData: notBreaching
 
     #==================================================
     # 3.7	Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs
@@ -1814,6 +1818,7 @@
         Period: 60
         Statistic: Sum
         Threshold: 1
+        TreatMissingData: notBreaching
 
 #==================================================
 # CloudWatch Event Rules
@@ -1963,7 +1968,7 @@
             eventName:
               - Decrypt
               - Encrypt
-        State: ENABLED
+        State: DISABLED
         Targets:
           -
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
@@ -2203,7 +2208,7 @@
         Period: 60
         Statistic: Sum
         Threshold: 1
-
+        TreatMissingData: notBreaching
     #==================================================
     # CIS 1.3	Ensure credentials unused for 90 days or greater are disabled
     # CIS 1.4	Ensure access keys are rotated every 90 days or less


### PR DESCRIPTION
Fixes following:
* Treat missing data as non-breaching to prevent CloudWatch state INSUFFICIENT
* Fix duplicate 'DependsOn' declare from ConfigRuleForEvaluateRootAccount
* Fix duplicate 'Description' declare from FunctionForEvaluateUserPolicyAssociationRule by removing incorrect VPC Flow log description